### PR TITLE
Add currency and format fields to CSV import configuration

### DIFF
--- a/app/controllers/import/configurations_controller.rb
+++ b/app/controllers/import/configurations_controller.rb
@@ -34,7 +34,9 @@ class Import::ConfigurationsController < ApplicationController
         :notes_col_label,
         :currency_col_label,
         :date_format,
-        :signage_convention
+        :signage_convention,
+        :currency,
+        :format
       )
     end
 end

--- a/app/helpers/imports_helper.rb
+++ b/app/helpers/imports_helper.rb
@@ -28,7 +28,7 @@ module ImportsHelper
   def dry_run_resource(key)
     map = {
       transactions: DryRunResource.new(label: "Transactions", icon: "credit-card", text_class: "text-cyan-500", bg_class: "bg-cyan-500/5"),
-      accounts: DryRunResource.new(label: "Accounts", icon: "layers", text_class: "text-orange-500", bg_class: "bg-orange-500/5"),
+      accounts: DryRunResource.new(label: "Accounts", icon: "layers", text_class: "text-orange-500", text_class: "text-orange-500", bg_class: "bg-orange-500/5"),
       categories: DryRunResource.new(label: "Categories", icon: "shapes", text_class: "text-blue-500", bg_class: "bg-blue-500/5"),
       tags: DryRunResource.new(label: "Tags", icon: "tags", text_class: "text-violet-500", bg_class: "bg-violet-500/5")
     }
@@ -52,6 +52,15 @@ module ImportsHelper
     border = row.errors.key?(field) ? "border-red-500" : "border-transparent"
 
     [ base, border ].join(" ")
+  end
+
+  def currency_options
+    currencies = YAML.load_file(Rails.root.join('config', 'currencies.yml'))
+    currencies.map { |key, value| [value['name'], key] }
+  end
+
+  def format_options
+    NUMBER_FORMATS.keys
   end
 
   private

--- a/app/models/import.rb
+++ b/app/models/import.rb
@@ -145,6 +145,6 @@ class Import < ApplicationRecord
 
     def sanitize_number(value)
       return "" if value.nil?
-      value.gsub(/[^\d.\-]/, "")
+      value.gsub(/[^\d#{format[:separator]}#{format[:delimiter]}]/, "")
     end
 end

--- a/app/views/import/configurations/_transaction_import.html.erb
+++ b/app/views/import/configurations/_transaction_import.html.erb
@@ -17,5 +17,8 @@
   <%= form.select :tags_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Tags (optional)" } %>
   <%= form.select :notes_col_label, import.csv_headers, { include_blank: "Leave empty", label: "Notes (optional)" } %>
 
+  <%= form.select :currency, options_for_select(ImportsHelper.currency_options), { include_blank: "Select currency", label: "Currency" }, required: true %>
+  <%= form.select :format, options_for_select(ImportsHelper.format_options), { include_blank: "Select format", label: "Format" }, required: true %>
+
   <%= form.submit "Apply configuration", class: "w-full btn btn--primary", disabled: import.complete? %>
 <% end %>


### PR DESCRIPTION
Add currency and format fields to CSV import configuration.

* Modify `app/controllers/import/configurations_controller.rb` to include `currency` and `format` in the `import_params` method.
* Update `app/views/import/configurations/_transaction_import.html.erb` to add select fields for `currency` and `format`.
* Modify `app/helpers/imports_helper.rb` to add methods for fetching currency and format options.
* Update `app/models/import.rb` to modify the `sanitize_number` method to handle the selected format.

